### PR TITLE
Add Support for Responsive Images

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ To have the browser determine when to load a high resolution image, use [respons
 
 ```html
 <div id="gallery" class="zoomwall">
-    <img srcset="./images/01_lowres.jpg 200w, ./images/01_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="./images/01_lowres.jpg">
-    <img srcset="./images/02_lowres.jpg 200w, ./images/02_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="./images/02_lowres.jpg">
+    <img srcset="01_lowres.jpg 200w, 01_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="01_lowres.jpg">
+    <img srcset="02_lowres.jpg 200w, 02_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="02_lowres.jpg">
 </div>
 ```
 
@@ -42,8 +42,8 @@ Include high resolution photos using the `data-highres` attribute of each `<img>
 
 ```html
 <div id="gallery" class="zoomwall">
-    <img src="./images/01_lowres.jpg" data-highres="./images/01_highres.jpg" />
-    <img src="./images/02_lowres.jpg" data-highres="./images/02_highres.jpg" />
+    <img src="01_lowres.jpg" data-highres="01_highres.jpg" />
+    <img src="02_lowres.jpg" data-highres="02_highres.jpg" />
 </div>
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,20 @@ First, add a reference to `zoomwall.js` and `zoomwall.css` in your HTML file, li
 <script type="text/javascript" src="zoomwall.js"></script>
 ```
 
-Add the `zoomwall` class to the container element. Include high resolution photos using the `data-highres` attribute of each `<img>` tag.
+Add the `zoomwall` class to the container element. 
+
+#### responsive images
+To have the browser determine when to load a high resolution image, use [responsive images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images).
+
+```html
+<div id="gallery" class="zoomwall">
+    <img srcset="./images/01_lowres.jpg 200w, ./images/01_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="./images/01_lowres.jpg">
+    <img srcset="./images/02_lowres.jpg 200w, ./images/02_highres.jpg 800w" sizes="(max-width: 1200px) 200px, 800px" src="./images/02_lowres.jpg">
+</div>
+```
+
+#### high resolution image
+Include high resolution photos using the `data-highres` attribute of each `<img>` tag.
 
 ```html
 <div id="gallery" class="zoomwall">

--- a/zoomwall.js
+++ b/zoomwall.js
@@ -159,6 +159,9 @@ export var zoomwall = {
     if (block.dataset.lowres) {
       block.src = block.dataset.lowres;
     }
+    if (block.dataset.sizes) {
+      block.sizes = block.dataset.sizes;
+    }
   },
 
   expand: function (block) {
@@ -195,6 +198,10 @@ export var zoomwall = {
         block.dataset.lowres = block.src;
       }
       block.src = block.dataset.highres;
+    }
+    if (block.sizes) { // responsive images
+      block.dataset.sizes = block.sizes;
+      block.sizes = "100vw" // image is now 100% of the viewport width
     }
 
     // determine what blocks are on this row
@@ -380,6 +387,9 @@ export var zoomwall = {
         // swap images
         if (current.dataset.lowres) {
           current.src = current.dataset.lowres;
+        }
+        if (current.dataset.sizes) {
+          current.sizes = current.dataset.sizes;
         }
 
         zoomwall.expand(next);

--- a/zoomwall.js
+++ b/zoomwall.js
@@ -201,7 +201,7 @@ export var zoomwall = {
     }
     if (block.sizes) { // responsive images
       block.dataset.sizes = block.sizes;
-      block.sizes = "100vw" // image is now 100% of the viewport width
+      block.sizes = '100vw'; // image is now 100% of the viewport width
     }
 
     // determine what blocks are on this row


### PR DESCRIPTION
Adds support for [responsive images](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images) rather than always loading the associated high resolution image in lightbox mode. This also allows for clients to provide multiple high resolution images.

This support works by checking for the `sizes` attribute and setting the attribute to `100vw` when an image is in lightbox mode. This indicates to the browser that the image is the full width of the viewport, causing the browser to load a higher resolution image if available.