### PR TITLE
Add Coveralls for Code Coverage CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,11 +28,21 @@ jobs:
       - run: npm run lint
       - run: npm run format-check
       - run: npm test
-
       - name: Code Coverage
         run: npm run cover:all
-
-      - name: Coveralls
+      - name: Coveralls Parallel
         uses: coverallsapp/github-action@master
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.github_token }}
+          flag-name: run-${{ matrix.test_number }}
+          parallel: true
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.github_token }}
+          parallel-finished: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,3 +28,11 @@ jobs:
       - run: npm run lint
       - run: npm run format-check
       - run: npm test
+
+      - name: Code Coverage
+        run: npm run cover:all
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -38,7 +38,7 @@ jobs:
           parallel: true
 
   finish:
-    needs: test
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Visit [ericleong.github.io/zoomwall.js](http://ericleong.github.io/zoomwall.js) 
 
 ![Node.js CI](https://github.com/ericleong/zoomwall.js/workflows/Node.js%20CI/badge.svg?branch=master)
 ![Node.js Package](https://github.com/ericleong/zoomwall.js/workflows/Node.js%20Package/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/ericleong/zoomwall.js/badge.svg?branch=master)](https://coveralls.io/github/ericleong/zoomwall.js?branch=master)
 
 ## install
 

--- a/scripts/patch-puppeteer-istanbul-output.js
+++ b/scripts/patch-puppeteer-istanbul-output.js
@@ -3,7 +3,7 @@ import * as path from "path";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const report = JSON.parse(
-  fs.readFileSync("./.nyc_output/out.json")?.toString()
+  fs.readFileSync("./.nyc_output/out.json").toString()
 );
 
 for (const key of Object.keys(report)) {

--- a/scripts/patch-puppeteer-istanbul-output.js
+++ b/scripts/patch-puppeteer-istanbul-output.js
@@ -2,9 +2,7 @@ import fs from "fs";
 import * as path from "path";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const report = JSON.parse(
-  fs.readFileSync("./.nyc_output/out.json").toString()
-);
+const report = JSON.parse(fs.readFileSync("./.nyc_output/out.json").toString());
 
 for (const key of Object.keys(report)) {
   if (key.endsWith("zoomwall.ts")) {


### PR DESCRIPTION
Adds a [Github Action for Coveralls](https://github.com/coverallsapp/github-action).

This is the badge for `master`: 
[![Coverage Status](https://coveralls.io/repos/github/ericleong/zoomwall.js/badge.svg?branch=master)](https://coveralls.io/github/ericleong/zoomwall.js?branch=master)
This is the badge for `coveralls`:
[![Coverage Status](https://coveralls.io/repos/github/ericleong/zoomwall.js/badge.svg?branch=coveralls)](https://coveralls.io/github/ericleong/zoomwall.js?branch=coveralls)