### PR TITLE
Add Test for Using Keyboard to View Previous Image

### DIFF
--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -128,6 +128,40 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
     );
   });
 
+  test("left arrow to go to previous image", async () => {
+    const gallery = await expect(page).toMatchElement("#gallery");
+
+    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
+      page
+    ).toMatchElement("#four");
+    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
+      page
+    ).toMatchElement("#five");
+    const fourthImgSrc = await fourthImg.evaluate((node) => node.src);
+    const fourthImgHigh = await fourthImg.evaluate(
+      (node) => node.dataset.highres
+    );
+
+    await page.keyboard.press("ArrowLeft");
+
+    expect(
+      Object.values(await gallery.evaluate((node) => node.classList))
+    ).toContain("lightbox");
+    expect(
+      Object.values(await fourthImg.evaluate((node) => node.classList))
+    ).toContain("active");
+    expect(
+      Object.values(await fifthImg.evaluate((node) => node.classList))
+    ).not.toContain("active");
+    expect(await fourthImg.evaluate((node) => node.style.transform)).toBe(
+      "translate(-300%, 0%) scale(4)"
+    );
+    expect(await fourthImg.evaluate((node) => node.src)).toBe(fourthImgHigh);
+    expect(await fourthImg.evaluate((node) => node.dataset.lowres)).toBe(
+      fourthImgSrc
+    );
+  });
+
   test("escape closes lightbox", async () => {
     const gallery = await expect(page).toMatchElement("#gallery");
     expect(


### PR DESCRIPTION
Adds test to press the left arrow button when an image is in the lightbox, which should make the lightbox go to the previous image.

Run `npm run test` and make sure the tests pass.