### PR TITLE
Pin Typedoc Version to 0.17.0-3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1810,6 +1810,12 @@
       "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
@@ -2210,12 +2216,6 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
     },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
-    },
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
@@ -2341,6 +2341,15 @@
       "requires": {
         "babel-plugin-jest-hoist": "^26.2.0",
         "babel-preset-current-node-syntax": "^0.1.3"
+      }
+    },
+    "backbone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.4.0.tgz",
+      "integrity": "sha512-RLmDrRXkVdouTg38jcgHhyQ/2zjg7a8E6sz2zxfz21Hh17xDJYUHBZimVIt5fUyS8vbfpeSmTL3gUjTEvUV3qQ==",
+      "dev": true,
+      "requires": {
+        "underscore": ">=1.8.3"
       }
     },
     "bail": {
@@ -4275,15 +4284,14 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
       "dev": true,
       "requires": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
       }
     },
     "fs.realpath": {
@@ -4629,9 +4637,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.1.2.tgz",
-      "integrity": "sha512-Q39v/Mn5mfBlMff9r+zzA+gWxRsCRKwEMvYTiisLr/XUiFI/4puWt0Ojdko3R3JCNWGdOWaA5g/Yxqa23kC5AA==",
+      "version": "9.18.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.3.tgz",
+      "integrity": "sha512-zBZAmhSupHIl5sITeMqIJnYCDfAEc3Gdkqj65wC1lpI468MMQeeQkhcIAvk+RylAkxrCcI9xy9piHiXeQ1BdzQ==",
       "dev": true
     },
     "homedir-polyfill": {
@@ -6545,6 +6553,12 @@
         }
       }
     },
+    "jquery": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6647,13 +6661,12 @@
       }
     },
     "jsonfile": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^1.0.0"
+        "graceful-fs": "^4.1.6"
       }
     },
     "jsprim": {
@@ -6885,9 +6898,9 @@
       }
     },
     "marked": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
-      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
     },
     "mathml-tag-names": {
@@ -9616,30 +9629,33 @@
       }
     },
     "typedoc": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.18.0.tgz",
-      "integrity": "sha512-UgDQwapCGQCCdYhEQzQ+kGutmcedklilgUGf62Vw6RdI29u6FcfAXFQfRTiJEbf16aK3YnkB20ctQK1JusCRbA==",
+      "version": "0.17.0-3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.17.0-3.tgz",
+      "integrity": "sha512-DO2djkR4NHgzAWfNbJb2eQKsFMs+gOuYBXlQ8dOSCjkAK5DRI7ZywDufBGPUw7Ue9Qwi2Cw1DxLd3reDq8wFuQ==",
       "dev": true,
       "requires": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.0.0",
+        "@types/minimatch": "3.0.3",
+        "fs-extra": "^8.1.0",
+        "handlebars": "^4.7.2",
+        "highlight.js": "^9.18.0",
         "lodash": "^4.17.15",
-        "lunr": "^2.3.8",
-        "marked": "^1.1.1",
+        "marked": "^0.8.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.10.2"
+        "shelljs": "^0.8.3",
+        "typedoc-default-themes": "0.8.0-0"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.10.2.tgz",
-      "integrity": "sha512-zo09yRj+xwLFE3hyhJeVHWRSPuKEIAsFK5r2u47KL/HBKqpwdUSanoaz5L34IKiSATFrjG5ywmIu98hPVMfxZg==",
+      "version": "0.8.0-0",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.8.0-0.tgz",
+      "integrity": "sha512-blFWppm5aKnaPOa1tpGO9MLu+njxq7P3rtkXK4QxJBNszA+Jg7x0b+Qx0liXU1acErur6r/iZdrwxp5DUFdSXw==",
       "dev": true,
       "requires": {
-        "lunr": "^2.3.8"
+        "backbone": "^1.4.0",
+        "jquery": "^3.4.1",
+        "lunr": "^2.3.8",
+        "underscore": "^1.9.1"
       }
     },
     "typescript": {
@@ -9654,6 +9670,12 @@
       "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
       "dev": true,
       "optional": true
+    },
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "dev": true
     },
     "unherit": {
       "version": "1.1.3",
@@ -9760,9 +9782,9 @@
       }
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unset-value": {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "stylelint-config-standard": "^20.0.0",
     "ts-jest": "^26.1.4",
     "ts-node": "^8.10.2",
-    "typedoc": "^0.18.0",
+    "typedoc": "0.17.0-3",
     "typescript": "^3.9.7"
   }
 }


### PR DESCRIPTION
Reverts #38 because `--mode library` is needed for [`/docs`](https://ericleong.github.io/zoomwall.js/docs). Although library mode was supposed to ship with typedoc `v0.18` (see https://github.com/TypeStrong/typedoc/pull/1184#issuecomment-653239597) it turns it out it hasn't shipped.

Check that docs build correctly with `npm run docs`.

The ["Publish GitHub Pages"](https://github.com/ericleong/zoomwall.js/actions?query=workflow%3A%22Publish+GitHub+Pages%22) should also work.