### PR TITLE
Fix Image Replacement When Closing Lightbox with Escape

### DIFF
--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -1,4 +1,7 @@
 module.exports = {
+  launch: {
+    headless: true,
+  },
   server: {
     command: "node lib/__tests__/server.js",
     port: 3000,

--- a/jest-puppeteer.config.cjs
+++ b/jest-puppeteer.config.cjs
@@ -1,7 +1,4 @@
 module.exports = {
-  launch: {
-    headless: true,
-  },
   server: {
     command: "node lib/__tests__/server.js",
     port: 3000,

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -251,33 +251,6 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
     );
   });
 
-  test(`clicking empty space closes lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
-
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#five");
-
-    await expect(page).toClick("#five");
-    // this clicks the gallery, not the image
-    await page.evaluate(() => {
-      document.getElementById("gallery")?.click();
-    });
-
-    expect(
-      Object.values(await gallery.evaluate((node) => node.classList))
-    ).not.toContain("lightbox");
-    expect(
-      Object.values(await img.evaluate((node) => node.classList))
-    ).not.toContain("active");
-    expect(await img.evaluate((node) => node.style.transform)).toBe(
-      "translate(0px, 0px) scale(1)"
-    );
-    expect(await img.evaluate((node) => node.src)).toBe(
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKcAAAD6AQMAAAD+yMWGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAADUExURaGhoWkNFFsAAAAcSURBVBgZ7cExAQAAAMIg+6deCU9gAAAAAADcBRV8AAE4UWJ7AAAAAElFTkSuQmCC"
-    );
-  });
-
   afterAll(async () => {
     const [jsCoverage] = await Promise.all([page.coverage.stopJSCoverage()]);
     // skips the javascript in the html file

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -240,6 +240,15 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
     expect(await fifthImg.evaluate((node) => node.style.transform)).toBe(
       "translate(0px, 0px) scale(1)"
     );
+    expect(await fourthImg.evaluate((node) => node.style.transform)).toBe(
+      "translate(0px, 0px) scale(1)"
+    );
+    expect(await fourthImg.evaluate((node) => node.src)).toBe(
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAPoAAACnAQMAAAACMtNXAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAADUExURX9/f5DKGyMAAAAcSURBVBgZ7cExAQAAAMIg+6deCj9gAAAAAAA8BRWHAAFREbyXAAAAAElFTkSuQmCC"
+    );
+    expect(await fifthImg.evaluate((node) => node.src)).toBe(
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKcAAAD6AQMAAAD+yMWGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAADUExURaGhoWkNFFsAAAAcSURBVBgZ7cExAQAAAMIg+6deCU9gAAAAAADcBRV8AAE4UWJ7AAAAAElFTkSuQmCC"
+    );
   });
 
   afterAll(async () => {

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -251,6 +251,33 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
     );
   });
 
+  test(`clicking empty space closes lightbox`, async () => {
+    const gallery = await expect(page).toMatchElement("#gallery");
+
+    const img: ElementHandle<HTMLImageElement> = await expect(
+      page
+    ).toMatchElement("#five");
+
+    await expect(page).toClick("#five");
+    // this clicks the gallery, not the image
+    await page.evaluate(() => {
+      document.getElementById("gallery")?.click();
+    });
+
+    expect(
+      Object.values(await gallery.evaluate((node) => node.classList))
+    ).not.toContain("lightbox");
+    expect(
+      Object.values(await img.evaluate((node) => node.classList))
+    ).not.toContain("active");
+    expect(await img.evaluate((node) => node.style.transform)).toBe(
+      "translate(0px, 0px) scale(1)"
+    );
+    expect(await img.evaluate((node) => node.src)).toBe(
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAKcAAAD6AQMAAAD+yMWGAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsIAAA7CARUoSoAAAAADUExURaGhoWkNFFsAAAAcSURBVBgZ7cExAQAAAMIg+6deCU9gAAAAAADcBRV8AAE4UWJ7AAAAAElFTkSuQmCC"
+    );
+  });
+
   afterAll(async () => {
     const [jsCoverage] = await Promise.all([page.coverage.stopJSCoverage()]);
     // skips the javascript in the html file

--- a/src/zoomwall.ts
+++ b/src/zoomwall.ts
@@ -164,9 +164,17 @@ function resize(blocks: HTMLElement[]): void {
     .forEach((row) => resizeRow(row, calcRowWidth(row)));
 }
 
-function reset(block: HTMLElement): void {
+function reset(block: HTMLImageElement): void {
   block.style.transform = "translate(0, 0) scale(1)";
   block.classList.remove("active");
+
+  // swap images
+  if (block.dataset.lowres) {
+    block.src = block.dataset.lowres;
+  }
+  if (block.dataset.sizes) {
+    block.sizes = block.dataset.sizes;
+  }
 }
 
 function shrink(block: HTMLImageElement): void {
@@ -179,14 +187,6 @@ function shrink(block: HTMLImageElement): void {
     blocks.querySelectorAll("img").forEach(function (img) {
       reset(img);
     });
-  }
-
-  // swap images
-  if (block.dataset.lowres) {
-    block.src = block.dataset.lowres;
-  }
-  if (block.dataset.sizes) {
-    block.sizes = block.dataset.sizes;
   }
 }
 


### PR DESCRIPTION
Previously, closing a lightbox with "Esc" would not cause the image to be replaced with the lower resolution version. This pull request fixes that. This pull request also tests that clicking an empty space in lightbox mode also causes the lightbox to be closed.

Test this pull request with `npm run test`.

Note that 36fc1c9 seems to fail because of a bug in Puppeteer: https://github.com/puppeteer/puppeteer/issues/1805