### PR TITLE
Remove "minimal" Theme that was Removed in #210

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc --project tsconfig.json",
     "source-map": "tsc --sourceMap --project tsconfig.json",
     "copy": "copyfiles -u 1 \"./src/zoomwall.css\" lib",
-    "docs": "typedoc --theme minimal --out docs src/zoomwall.ts",
+    "docs": "typedoc --out docs src/zoomwall.ts",
     "gpr-package-rename": "node scripts/gpr-package-rename.cjs",
     "lint-js": "eslint \"**/*.{ts,js,mjs,cjs}\"",
     "lint-css": "stylelint \"**/*.css\"",


### PR DESCRIPTION
Fix [error](https://github.com/ericleong/zoomwall.js/runs/3591009180) caused by missing "minimal" theme in typedoc, which was updated in #210 

```
Run npm run docs

> zoomwall.js@2.0.2 docs /home/runner/work/zoomwall.js/zoomwall.js
> typedoc --theme minimal --out docs src/zoomwall.ts

Error: The theme 'minimal' is not defined. The available themes are: default
Error: Documentation could not be generated due to the errors above.
npm ERR! code ELIFECYCLE
npm ERR! errno 5
npm ERR! zoomwall.js@2.0.2 docs: `typedoc --theme minimal --out docs src/zoomwall.ts`
npm ERR! Exit status 5
npm ERR! 
npm ERR! Failed at the zoomwall.js@2.0.2 docs script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2021-09-13T19_10_18_164Z-debug.log
Error: Process completed with exit code 5.
```