### PR TITLE
Remove Current Directory From Files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "./lib/zoomwall.js",
   "types": "./lib/zoomwall.d.ts",
   "files": [
-    "./lib/zoomwall.js",
-    "./lib/zoomwall.css"
+    "lib/zoomwall.js",
+    "lib/zoomwall.css"
   ],
   "scripts": {
     "build": "tsc --project tsconfig.json",


### PR DESCRIPTION
It seems the specified output files are not published if they include the current directory (`.`) in the file path. Fixes #268

#### Test

Run `npm publish --dry-run` and make sure `lib/zoomwall.js` and `lib/zoomwall.css` are in the tarball contents.