### PR TITLE
Install npm@8 in Github Actions for Github Dependencies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/setup-node@v2.5.1
         with:
           node-version: 12
+      - name: Update to npm@8 for github deps
+        run: npm install -g npm@8
       - run: npm ci
       - run: npm test
 
@@ -27,6 +29,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+      - name: Update to npm@8 for github deps
+        run: npm install -g npm@8
       - run: npm ci
       - run: npm publish
         env:
@@ -41,6 +45,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://npm.pkg.github.com/
+      - name: Update to npm@8 for github deps
+        run: npm install -g npm@8
       - run: npm ci
       - run: npm run gpr-package-rename
       - run: npm publish

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-node@v2.5.1
         with:
           node-version: 12
+      - name: Update to npm@8 for github deps
+        run: npm install -g npm@8
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run docs


### PR DESCRIPTION
Caused by https://github.com/ericleong/zoomwall.js/runs/5144116258

Installs `npm@8` for Github dependencies with the new lockfile. The issue is related to https://github.com/actions/setup-node/issues/214

Note that the issue could also be fixed by upgrading node to v16, which may be done at a later date.