### PR TITLE
Add Node 16 to Version Matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2.4.0


### PR DESCRIPTION
Node v16 has been out for about a year and Node v12 will be deprecated soon: https://nodejs.org/en/about/releases/ 

Moving to Node v16 should mitigate issues with npm and Github, which needed to be upgraded to npm@8: see #278 and #282