### PR TITLE
Update Node Version to 16 in Github Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
 
     steps:
       - uses: actions/checkout@v2.4.0

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Update to npm@8 for github deps
-        run: npm install -g npm@8
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run lint

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Update to npm@8 for github deps
-        run: npm install -g npm@8
       - run: npm ci
       - run: npm test
 
@@ -29,8 +27,6 @@ jobs:
         with:
           node-version: 16
           registry-url: https://registry.npmjs.org/
-      - name: Update to npm@8 for github deps
-        run: npm install -g npm@8
       - run: npm ci
       - run: npm publish
         env:
@@ -45,8 +41,6 @@ jobs:
         with:
           node-version: 16
           registry-url: https://npm.pkg.github.com/
-      - name: Update to npm@8 for github deps
-        run: npm install -g npm@8
       - run: npm ci
       - run: npm run gpr-package-rename
       - run: npm publish

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
       - name: Update to npm@8 for github deps
         run: npm install -g npm@8
       - run: npm ci
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
       - name: Update to npm@8 for github deps
         run: npm install -g npm@8
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2.4.0
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://npm.pkg.github.com/
       - name: Update to npm@8 for github deps
         run: npm install -g npm@8

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -13,8 +13,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16
-      - name: Update to npm@8 for github deps
-        run: npm install -g npm@8
       - run: npm ci
       - run: npm run build --if-present
       - run: npm run docs

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
       - name: Update to npm@8 for github deps
         run: npm install -g npm@8
       - run: npm ci


### PR DESCRIPTION
After #297, `actions/setup-node@v3` now uses Node 16, so there is no need to install `npm@8` or force an older version of Node.