### PR TITLE
Bump puppeteer from 14.4.1 to 15.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "jest-puppeteer": "^6.0.0",
         "nyc": "^15.1.0",
         "prettier": "2.7.1",
-        "puppeteer": "^15.0.2",
+        "puppeteer": "^15.1.1",
         "puppeteer-to-istanbul": "github:skerit/puppeteer-to-istanbul#d0ebc44",
         "source-map-support": "^0.5.19",
         "stylelint": "^14.5.0",
@@ -3145,9 +3145,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1001819",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
-      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==",
+      "version": "0.0.1011705",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
+      "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==",
       "dev": true
     },
     "node_modules/diff": {
@@ -8322,15 +8322,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.0.2.tgz",
-      "integrity": "sha512-7gJkr2skctdyRn9hACFw8olqtbnUXxT7LZ2dQT5krUgB30TsAUZ5c/NDQ/4H3514IrDB9DmKqZGHT0I369SvAQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.1.1.tgz",
+      "integrity": "sha512-XMysu48uIcaYad/IelRTX3yxpHkcNdhdzPegnBEz9h1uEQfLhFcMJnjyvus51Sm+OPwr2gaKQhtyuIVaVKqd0Q==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.1011705",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
@@ -13445,9 +13445,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.1001819",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
-      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ==",
+      "version": "0.0.1011705",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
+      "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q==",
       "dev": true
     },
     "diff": {
@@ -17545,14 +17545,14 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.0.2.tgz",
-      "integrity": "sha512-7gJkr2skctdyRn9hACFw8olqtbnUXxT7LZ2dQT5krUgB30TsAUZ5c/NDQ/4H3514IrDB9DmKqZGHT0I369SvAQ==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.1.1.tgz",
+      "integrity": "sha512-XMysu48uIcaYad/IelRTX3yxpHkcNdhdzPegnBEz9h1uEQfLhFcMJnjyvus51Sm+OPwr2gaKQhtyuIVaVKqd0Q==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.1001819",
+        "devtools-protocol": "0.0.1011705",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "jest-puppeteer": "^6.0.0",
         "nyc": "^15.1.0",
         "prettier": "2.7.1",
-        "puppeteer": "^14.0.0",
+        "puppeteer": "^15.0.2",
         "puppeteer-to-istanbul": "github:skerit/puppeteer-to-istanbul#d0ebc44",
         "source-map-support": "^0.5.19",
         "stylelint": "^14.5.0",
@@ -8322,9 +8322,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.4.1.tgz",
-      "integrity": "sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.0.2.tgz",
+      "integrity": "sha512-7gJkr2skctdyRn9hACFw8olqtbnUXxT7LZ2dQT5krUgB30TsAUZ5c/NDQ/4H3514IrDB9DmKqZGHT0I369SvAQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8339,7 +8339,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.7.0"
+        "ws": "8.8.0"
       },
       "engines": {
         "node": ">=14.1.0"
@@ -8447,9 +8447,9 @@
       }
     },
     "node_modules/puppeteer/node_modules/ws": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-      "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+      "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -17545,9 +17545,9 @@
       "dev": true
     },
     "puppeteer": {
-      "version": "14.4.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-14.4.1.tgz",
-      "integrity": "sha512-+H0Gm84aXUvSLdSiDROtLlOofftClgw2TdceMvvCU9UvMryappoeS3+eOLfKvoy4sm8B8MWnYmPhWxVFudAOFQ==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-15.0.2.tgz",
+      "integrity": "sha512-7gJkr2skctdyRn9hACFw8olqtbnUXxT7LZ2dQT5krUgB30TsAUZ5c/NDQ/4H3514IrDB9DmKqZGHT0I369SvAQ==",
       "dev": true,
       "requires": {
         "cross-fetch": "3.1.5",
@@ -17561,13 +17561,13 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.7.0"
+        "ws": "8.8.0"
       },
       "dependencies": {
         "ws": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
-          "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
+          "version": "8.8.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+          "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
           "dev": true,
           "requires": {}
         }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest-puppeteer": "^6.0.0",
     "nyc": "^15.1.0",
     "prettier": "2.7.1",
-    "puppeteer": "^14.0.0",
+    "puppeteer": "^15.0.2",
     "puppeteer-to-istanbul": "github:skerit/puppeteer-to-istanbul#d0ebc44",
     "source-map-support": "^0.5.19",
     "stylelint": "^14.5.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest-puppeteer": "^6.0.0",
     "nyc": "^15.1.0",
     "prettier": "2.7.1",
-    "puppeteer": "^15.0.2",
+    "puppeteer": "^15.1.1",
     "puppeteer-to-istanbul": "github:skerit/puppeteer-to-istanbul#d0ebc44",
     "source-map-support": "^0.5.19",
     "stylelint": "^14.5.0",

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -27,9 +27,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to open dataset lightbox`, async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -72,9 +70,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to close dataset lightbox`, async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -109,9 +105,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to advance dataset lightbox`, async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -159,9 +153,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to open srcset lightbox`, async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -198,9 +190,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to close srcset lightbox`, async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -232,9 +222,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("right arrow to advance to next image", async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
 
     // open lightbox
     await expect(page).toClick("#four");
@@ -301,9 +289,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("left arrow to go to previous image", async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
 
     const fourthImg = (await expect(page).toMatchElement(
       "#four"
@@ -355,9 +341,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("escape closes lightbox", async () => {
-    const gallery = (await expect(page).toMatchElement(
-      "#gallery"
-    )) as HandleFor<Element>;
+    const gallery = await expect(page).toMatchElement("#gallery");
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
@@ -427,12 +411,8 @@ describe("multiple galleries with keyboards", () => {
   });
 
   test("right arrow to advance to next image in second gallery", async () => {
-    const flat = (await expect(page).toMatchElement(
-      "#flat"
-    )) as HandleFor<Element>;
-    const nested = (await expect(page).toMatchElement(
-      "#nested"
-    )) as HandleFor<Element>;
+    const flat = await expect(page).toMatchElement("#flat");
+    const nested = await expect(page).toMatchElement("#nested");
 
     // open second lightbox
     await expect(page).toClick("#nested-four");
@@ -504,9 +484,7 @@ describe("multiple galleries with keyboards", () => {
   });
 
   test("escape closes first lightbox", async () => {
-    const flat = (await expect(page).toMatchElement(
-      "#flat"
-    )) as HandleFor<Element>;
+    const flat = await expect(page).toMatchElement("#flat");
     // open first lightbox
     await expect(page).toClick("#flat-four");
     expect(
@@ -515,9 +493,7 @@ describe("multiple galleries with keyboards", () => {
       )
     ).toContain("lightbox");
 
-    const nested = (await expect(page).toMatchElement(
-      "#nested"
-    )) as HandleFor<Element>;
+    const nested = await expect(page).toMatchElement("#nested");
     expect(
       Object.values(
         await nested.evaluate((node: Element): DOMTokenList => node.classList)

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -1,6 +1,6 @@
 import "expect-puppeteer";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { CoverageEntry, HandleFor } from "puppeteer";
+import { CoverageEntry, ElementHandle } from "puppeteer";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const pti = require("puppeteer-to-istanbul");
 const totalJsCoverage: CoverageEntry[] = [];
@@ -14,13 +14,13 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   test("resize images on create", async () => {
     const fourthImg = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     expect(
       await fourthImg.evaluate((node: HTMLElement): string => node.style.width)
     ).toBe("25%");
     const fifthImg = (await expect(page).toMatchElement(
       "#five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     expect(
       await fifthImg.evaluate((node: HTMLElement): string => node.style.width)
     ).toBe("10.3093%");
@@ -36,7 +36,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const img = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const imgSrc = await img.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -79,7 +79,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const img = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const imgLow = await img.evaluate(
       (node: HTMLElement): string => node.dataset.lowres as string
     );
@@ -114,7 +114,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const img = (await expect(page).toMatchElement(
       "#six"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const imgSrc = await img.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -162,7 +162,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const img = (await expect(page).toMatchElement(
       "#ten"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
 
     await expect(page).toClick("#ten");
 
@@ -199,7 +199,7 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const img = (await expect(page).toMatchElement(
       "#ten"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
 
     await expect(page).toClick("#ten");
 
@@ -234,10 +234,10 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const fourthImg = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImg = (await expect(page).toMatchElement(
       "#five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImgSrc = await fifthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -293,10 +293,10 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const fourthImg = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImg = (await expect(page).toMatchElement(
       "#five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fourthImgSrc = await fourthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -350,10 +350,10 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
 
     const fourthImg = (await expect(page).toMatchElement(
       "#four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImg = (await expect(page).toMatchElement(
       "#five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
 
     await page.keyboard.press("Escape");
 
@@ -424,10 +424,10 @@ describe("multiple galleries with keyboards", () => {
 
     const fourthImg = (await expect(page).toMatchElement(
       "#nested-four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImg = (await expect(page).toMatchElement(
       "#nested-five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const fifthImgSrc = await fifthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -502,17 +502,17 @@ describe("multiple galleries with keyboards", () => {
 
     const firstFourthImg = (await expect(page).toMatchElement(
       "#flat-four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const firstFifthImg = (await expect(page).toMatchElement(
       "#flat-five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
 
     const secondFourthImg = (await expect(page).toMatchElement(
       "#nested-four"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
     const secondFifthImg = (await expect(page).toMatchElement(
       "#nested-five"
-    )) as HandleFor<HTMLImageElement>;
+    )) as ElementHandle<HTMLImageElement>;
 
     await page.keyboard.press("Escape");
 

--- a/src/__tests__/functional.test.ts
+++ b/src/__tests__/functional.test.ts
@@ -1,6 +1,6 @@
 import "expect-puppeteer";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ElementHandle, CoverageEntry } from "puppeteer";
+import { CoverageEntry, HandleFor } from "puppeteer";
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const pti = require("puppeteer-to-istanbul");
 const totalJsCoverage: CoverageEntry[] = [];
@@ -12,31 +12,33 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("resize images on create", async () => {
-    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
+    const fourthImg = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
     expect(
       await fourthImg.evaluate((node: HTMLElement): string => node.style.width)
     ).toBe("25%");
-    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#five");
+    const fifthImg = (await expect(page).toMatchElement(
+      "#five"
+    )) as HandleFor<HTMLImageElement>;
     expect(
       await fifthImg.evaluate((node: HTMLElement): string => node.style.width)
     ).toBe("10.3093%");
   });
 
   test(`click to open dataset lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).not.toContain("lightbox");
 
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
+    const img = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
     const imgSrc = await img.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -70,16 +72,18 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to close dataset lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).toContain("lightbox");
 
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
+    const img = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
     const imgLow = await img.evaluate(
       (node: HTMLElement): string => node.dataset.lowres as string
     );
@@ -105,16 +109,18 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to advance dataset lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).not.toContain("lightbox");
 
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#six");
+    const img = (await expect(page).toMatchElement(
+      "#six"
+    )) as HandleFor<HTMLImageElement>;
     const imgSrc = await img.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -122,9 +128,9 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
       (node: HTMLElement): string => node.dataset.highres as string
     );
 
-    await page.waitFor(200);
+    await page.waitForTimeout(200);
     await expect(page).toClick("#five");
-    await page.waitFor(200);
+    await page.waitForTimeout(200);
     await expect(page).toClick("#six");
 
     expect(
@@ -153,16 +159,18 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to open srcset lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).not.toContain("lightbox");
 
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#ten");
+    const img = (await expect(page).toMatchElement(
+      "#ten"
+    )) as HandleFor<HTMLImageElement>;
 
     await expect(page).toClick("#ten");
 
@@ -190,16 +198,18 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test(`click to close srcset lightbox`, async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).toContain("lightbox");
 
-    const img: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#ten");
+    const img = (await expect(page).toMatchElement(
+      "#ten"
+    )) as HandleFor<HTMLImageElement>;
 
     await expect(page).toClick("#ten");
 
@@ -222,7 +232,9 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("right arrow to advance to next image", async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
 
     // open lightbox
     await expect(page).toClick("#four");
@@ -232,12 +244,12 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
       )
     ).toContain("lightbox");
 
-    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
-    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#five");
+    const fourthImg = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
+    const fifthImg = (await expect(page).toMatchElement(
+      "#five"
+    )) as HandleFor<HTMLImageElement>;
     const fifthImgSrc = await fifthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -289,14 +301,16 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("left arrow to go to previous image", async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
 
-    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
-    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#five");
+    const fourthImg = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
+    const fifthImg = (await expect(page).toMatchElement(
+      "#five"
+    )) as HandleFor<HTMLImageElement>;
     const fourthImgSrc = await fourthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -341,19 +355,21 @@ describe.each(["flat", "nested"])("interaction tests %s", (type) => {
   });
 
   test("escape closes lightbox", async () => {
-    const gallery = await expect(page).toMatchElement("#gallery");
+    const gallery = (await expect(page).toMatchElement(
+      "#gallery"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await gallery.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).toContain("lightbox");
 
-    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#four");
-    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#five");
+    const fourthImg = (await expect(page).toMatchElement(
+      "#four"
+    )) as HandleFor<HTMLImageElement>;
+    const fifthImg = (await expect(page).toMatchElement(
+      "#five"
+    )) as HandleFor<HTMLImageElement>;
 
     await page.keyboard.press("Escape");
 
@@ -411,8 +427,12 @@ describe("multiple galleries with keyboards", () => {
   });
 
   test("right arrow to advance to next image in second gallery", async () => {
-    const flat = await expect(page).toMatchElement("#flat");
-    const nested = await expect(page).toMatchElement("#nested");
+    const flat = (await expect(page).toMatchElement(
+      "#flat"
+    )) as HandleFor<Element>;
+    const nested = (await expect(page).toMatchElement(
+      "#nested"
+    )) as HandleFor<Element>;
 
     // open second lightbox
     await expect(page).toClick("#nested-four");
@@ -422,12 +442,12 @@ describe("multiple galleries with keyboards", () => {
       )
     ).toContain("lightbox");
 
-    const fourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#nested-four");
-    const fifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#nested-five");
+    const fourthImg = (await expect(page).toMatchElement(
+      "#nested-four"
+    )) as HandleFor<HTMLImageElement>;
+    const fifthImg = (await expect(page).toMatchElement(
+      "#nested-five"
+    )) as HandleFor<HTMLImageElement>;
     const fifthImgSrc = await fifthImg.evaluate(
       (node: HTMLImageElement): string => node.src
     );
@@ -484,7 +504,9 @@ describe("multiple galleries with keyboards", () => {
   });
 
   test("escape closes first lightbox", async () => {
-    const flat = await expect(page).toMatchElement("#flat");
+    const flat = (await expect(page).toMatchElement(
+      "#flat"
+    )) as HandleFor<Element>;
     // open first lightbox
     await expect(page).toClick("#flat-four");
     expect(
@@ -493,26 +515,28 @@ describe("multiple galleries with keyboards", () => {
       )
     ).toContain("lightbox");
 
-    const nested = await expect(page).toMatchElement("#nested");
+    const nested = (await expect(page).toMatchElement(
+      "#nested"
+    )) as HandleFor<Element>;
     expect(
       Object.values(
         await nested.evaluate((node: Element): DOMTokenList => node.classList)
       )
     ).toContain("lightbox");
 
-    const firstFourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#flat-four");
-    const firstFifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#flat-five");
+    const firstFourthImg = (await expect(page).toMatchElement(
+      "#flat-four"
+    )) as HandleFor<HTMLImageElement>;
+    const firstFifthImg = (await expect(page).toMatchElement(
+      "#flat-five"
+    )) as HandleFor<HTMLImageElement>;
 
-    const secondFourthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#nested-four");
-    const secondFifthImg: ElementHandle<HTMLImageElement> = await expect(
-      page
-    ).toMatchElement("#nested-five");
+    const secondFourthImg = (await expect(page).toMatchElement(
+      "#nested-four"
+    )) as HandleFor<HTMLImageElement>;
+    const secondFifthImg = (await expect(page).toMatchElement(
+      "#nested-five"
+    )) as HandleFor<HTMLImageElement>;
 
     await page.keyboard.press("Escape");
 


### PR DESCRIPTION
Resolves breaking changes introduced with Puppeteer 15 and found in #404 

* ~~Replace `ElementHandle` with `HandleFor`~~ **Fixed by [puppeteer 15.1.1](https://github.com/puppeteer/puppeteer/releases/tag/v15.1.1)**
* Use `as ...` instead of setting a return type
* Replace `Page.waitFor()` with `Page.waitForTimeout()`