### PR TITLE
Fix Lighbox Issue with Galleries with More Than Ten Rows

### DIFF
--- a/src/zoomwall.ts
+++ b/src/zoomwall.ts
@@ -282,7 +282,7 @@ function expand(block: HTMLImageElement): void {
       Math.sign(rowIndex - selectedIndex) *
         (scale - 1) *
         rowHeights
-          .slice(...[selectedIndex, rowIndex].sort())
+          .slice(...[selectedIndex, rowIndex].sort((a, b) => a - b))
           .reduce((offset, height) => offset + height, 0) -
       offsetY;
 


### PR DESCRIPTION
Apparently `sort()` [converts the items to strings before sorting](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort). This pull request fixes it so that the row indices are sorted numerically. 

Fixes #507

Although I'm tempted to write a test for this, it's primarily a quirk of Javascript (what is the next number of rows that would cause a bug?).